### PR TITLE
Run gtest suite in CI and add gtest target/Makefile

### DIFF
--- a/.github/workflows/build_and_analysis.yml
+++ b/.github/workflows/build_and_analysis.yml
@@ -8,7 +8,9 @@ jobs:
       - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Install dependencies
-        run: sudo apt update
+        run: |
+          sudo apt update
+          sudo apt install -y libgtest-dev pkg-config
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
@@ -18,6 +20,10 @@ jobs:
         run: make --directory=${{ github.workspace }}/compiler
       - name: Test Mana compiler
         run: make --directory=${{ github.workspace }}/compiler test
+      - name: Run unit tests
+        run: |
+          make --directory=${{ github.workspace }}/compiler gtest
+          ${{ github.workspace }}/test/gtest/mana_gtests
   BuildOnWindows:
     runs-on: windows-latest
     steps:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -72,6 +72,7 @@ all:
 
 clean:
 	$(RM) $(TARGET) $(SECOUND) $(OBJECTS)
+	$(MAKE) -C ../test/gtest clean
 
 depend:
 	makedepend -Y -- $(CFLAGS) -- $(SOURCES)
@@ -82,6 +83,9 @@ cppcheck:
 test:
 	./$(TARGET) --debug ../sample/sample.mn
 	cd ../test/ && python3 test.py
+
+gtest:
+	$(MAKE) -C ../test/gtest
 
 version:
 	python3 Version.py

--- a/test/gtest/Makefile
+++ b/test/gtest/Makefile
@@ -1,0 +1,28 @@
+CXX ?= g++
+CXXFLAGS ?= -std=c++17 -O2 -Wall -I../../compiler -I../../runner
+LDFLAGS ?=
+GTEST_CFLAGS ?= $(shell pkg-config --cflags gtest 2>/dev/null)
+GTEST_LIBS ?= $(shell pkg-config --libs gtest 2>/dev/null)
+
+TARGET = mana_gtests
+
+SOURCES = \
+	../../compiler/Path.cpp \
+	../../compiler/StringPool.cpp \
+	test_path.cpp \
+	test_string_pool.cpp
+
+OBJECTS = $(SOURCES:.cpp=.o)
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(GTEST_CFLAGS) -o $@ $(OBJECTS) $(LDFLAGS) $(GTEST_LIBS) -lgtest -pthread
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $(GTEST_CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f $(TARGET) $(OBJECTS)
+
+.PHONY: all clean

--- a/test/gtest/test_path.cpp
+++ b/test/gtest/test_path.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include "Path.h"
+
+#include <array>
+
+namespace mana::tests {
+
+TEST(PathTest, PathSeparatorMatchesPlatform) {
+#if defined(MANA_TARGET_WINDOWS)
+  EXPECT_EQ(PathSeparator(), '\\');
+#else
+  EXPECT_EQ(PathSeparator(), '/');
+#endif
+}
+
+TEST(PathTest, SplitAndMakePathRoundTrip) {
+#if defined(MANA_TARGET_WINDOWS)
+  const char* input = "C:\\tmp\\mana_test.txt";
+#else
+  const char* input = "/tmp/mana_test.txt";
+#endif
+
+  std::array<char, _MAX_DRIVE> drive{};
+  std::array<char, _MAX_DIR> dir{};
+  std::array<char, _MAX_FNAME> file{};
+  std::array<char, _MAX_EXT> ext{};
+
+  splitpath(input,
+            drive.data(), drive.size(),
+            dir.data(), dir.size(),
+            file.data(), file.size(),
+            ext.data(), ext.size());
+
+  std::array<char, _MAX_PATH> output{};
+  makepath(output.data(), output.size(),
+           drive.data(), dir.data(), file.data(), ext.data());
+
+  EXPECT_STREQ(output.data(), input);
+}
+
+TEST(PathTest, FullpathReturnsValue) {
+  std::array<char, _MAX_PATH> output{};
+  EXPECT_NE(fullpath(output.data(), ".", output.size()), nullptr);
+}
+
+}  // namespace mana::tests

--- a/test/gtest/test_string_pool.cpp
+++ b/test/gtest/test_string_pool.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include "StringPool.h"
+
+namespace mana::tests {
+
+TEST(StringPoolTest, SetReturnsPooledView) {
+  StringPool pool;
+  const auto pooled = pool.Set("alpha");
+
+  EXPECT_EQ(pooled, "alpha");
+}
+
+TEST(StringPoolTest, SetDeduplicatesStrings) {
+  StringPool pool;
+
+  const auto first = pool.Set("dup");
+  const auto second = pool.Set("dup");
+
+  EXPECT_EQ(first, second);
+  EXPECT_EQ(first.data(), second.data());
+}
+
+TEST(StringPoolTest, GetReturnsEmptyForMissing) {
+  StringPool pool;
+
+  const auto result = pool.Get("missing");
+
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(StringPoolTest, GetReturnsExistingString) {
+  StringPool pool;
+  pool.Set("beta");
+
+  const auto result = pool.Get("beta");
+
+  EXPECT_EQ(result, "beta");
+}
+
+}  // namespace mana::tests


### PR DESCRIPTION
### Motivation
- Ensure the existing GoogleTest unit tests (`test/gtest/*.cpp`) are built against the real production code and executed in CI.  
- Add a reproducible Make-based build path for running unit tests locally via `make gtest`.  
- Keep CI images prepared with required packages (`libgtest-dev` and `pkg-config`) so gtest can be built/executed.  

### Description
- Added `test/gtest/Makefile` to build `mana_gtests` from `test_path.cpp`, `test_string_pool.cpp`, and the production `Path.cpp`/`StringPool.cpp`.  
- Added new tests `test/gtest/test_path.cpp` and `test/gtest/test_string_pool.cpp` to validate `Path` and `StringPool` behaviors.  
- Updated `compiler/Makefile` to run `make -C ../test/gtest clean` in `clean` and to add a `gtest` target that builds the test suite.  
- Updated CI workflow `/.github/workflows/build_and_analysis.yml` to install `libgtest-dev` and `pkg-config` and to build and run the `mana_gtests` binary via `make --directory=${{ github.workspace }}/compiler gtest` and executing `test/gtest/mana_gtests`.  

### Testing
- No automated tests were executed as part of this change.  
- CI will now build and run the gtest binary when the workflow executes, but this run has not been performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696390010d7c8323bd02380e752e8b55)