### PR TITLE
Add tag-triggered Windows release zip workflow

### DIFF
--- a/.github/workflows/release_windows_zip.yml
+++ b/.github/workflows/release_windows_zip.yml
@@ -1,0 +1,56 @@
+name: release-windows-zip
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows-zip:
+    runs-on: windows-latest
+    steps:
+      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "The name of your tag is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Set up Cygwin
+        uses: egor-tensin/setup-cygwin@v3
+        with:
+          platform: x64
+          packages: bison flex python3 make clang
+      - name: Add Environment variables
+        run: |
+          echo "GNU_BISON_BIN=C:\tools\cygwin\bin\bison.exe" >> $env:GITHUB_ENV
+          echo "GNU_FLEX_BIN=C:\tools\cygwin\bin\flex.exe" >> $env:GITHUB_ENV
+          echo "PYTHON_BIN=C:\tools\cygwin\bin\python3.9.exe" >> $env:GITHUB_ENV
+          echo $env:GNU_BISON_BIN
+          echo $env:GNU_FLEX_BIN
+          echo $env:PYTHON_BIN
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Generate Mana version infomation
+        working-directory: ./compiler
+        run: ${{env.PYTHON_BIN}} Version.py
+      - name: Build Mana 64bit compiler
+        run: msbuild mana.sln /t:build /p:Configuration=Release /p:Platform=x64
+      - name: Prepare release zip
+        shell: pwsh
+        run: |
+          $stage = Join-Path $env:RUNNER_TEMP "release-stage"
+          $win64 = Join-Path $stage "Win64"
+          New-Item -ItemType Directory -Force -Path $win64 | Out-Null
+          Copy-Item -Path "x64/Release/mana.exe" -Destination (Join-Path $win64 "Mana.exe")
+          Copy-Item -Path "runner" -Destination (Join-Path $stage "runner") -Recurse
+          Copy-Item -Path "LICENSE.md" -Destination (Join-Path $stage "LICENSE.md")
+          $zipPath = Join-Path $env:RUNNER_TEMP "Mana-Windows-Release.zip"
+          if (Test-Path $zipPath) { Remove-Item $zipPath }
+          Compress-Archive -Path (Join-Path $stage "*") -DestinationPath $zipPath
+          "ZIP_PATH=$zipPath" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.ZIP_PATH }}


### PR DESCRIPTION
### Motivation

- Automatically produce a Windows release ZIP when a git tag is pushed so binary artifacts can be attached to a GitHub release. 
- The ZIP must include the `Win64/Mana.exe`, the `runner` directory, and `LICENSE.md` for distribution.

### Description

- Add a new workflow file `.github/workflows/release_windows_zip.yml` that triggers on `push` of tags and sets `permissions: contents: write`.
- The workflow sets up `msbuild` and Cygwin, exports required env variables, checks out the repo, runs `Version.py`, and builds the x64 Release with `msbuild mana.sln /t:build /p:Configuration=Release /p:Platform=x64`.
- A PowerShell staging step creates a `release-stage` directory, copies `x64/Release/mana.exe` to `Win64/Mana.exe`, copies the entire `runner` directory and `LICENSE.md`, compresses the stage into `Mana-Windows-Release.zip` in `$env:RUNNER_TEMP`, and writes `ZIP_PATH` to the environment.
- The workflow uploads the produced zip to the GitHub release using `softprops/action-gh-release@v1`.

### Testing

- No automated tests were executed for this change because it adds a new GitHub Actions workflow and the workflow has not been run in CI yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db52da0248323972b03b5cd2d331a)