### PR TITLE
Preserve forward-declared using scopes

### DIFF
--- a/compiler/GlobalSemanticAnalyzer.cpp
+++ b/compiler/GlobalSemanticAnalyzer.cpp
@@ -424,9 +424,25 @@ namespace mana
 
 		const bool isNamespace = mNamespaceRegistry && mNamespaceRegistry->IsNamespace(candidateName);
 		const bool isSymbol = IsActorSymbol(candidateName);
+		const bool isQualified = IsQualifiedName(name);
 
 		if (isNamespace && isSymbol)
 			return;
+
+		if (!isNamespace && !isSymbol)
+		{
+			if (!mUsingScopes.empty())
+				mUsingScopes.back().namespacePaths.push_back(candidateName);
+
+			if (isQualified && !mUsingScopes.empty())
+			{
+				const std::string_view alias = GetLastSegment(name);
+				auto& aliases = mUsingScopes.back().symbolAliases;
+				if (aliases.find(alias) == aliases.end())
+					aliases.emplace(alias, candidateName);
+			}
+			return;
+		}
 
 		if (isNamespace)
 		{


### PR DESCRIPTION
### Motivation
- Fix dropped `using` entries for forward-declared namespaces/symbols that caused later references to fail with "incomplete type name" by preserving the `using` information even when the target isn't known yet.

### Description
- Update `GlobalSemanticAnalyzer::ResolveUsingDeclaration` in `compiler/GlobalSemanticAnalyzer.cpp` to record `namespacePaths` for candidates that are neither recognized as a namespace nor a symbol, and to record a qualified alias mapping when the original `using` is a qualified name.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976402b76488323886681e3b7a07e66)