### PR TITLE
Detect ambiguous type names across using namespaces

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -75,6 +75,7 @@ success('test_using_namespace.mn')
 success('test_using_symbol.mn')
 success('test_forward_reference_using.mn')
 fail('test_using_ambiguous_actor.mn', 'ambiguous actor reference')
+fail('test_using_ambiguous_type.mn', 'ambiguous type reference')
 fail('test_using_ambiguous_namespace_symbol.mn', 'ambiguous using')
 success('test_extend_namespace_resolution.mn')
 ################################################################################

--- a/test/test_using_ambiguous_type.mn
+++ b/test/test_using_ambiguous_type.mn
@@ -1,0 +1,26 @@
+namespace A
+{
+	struct S
+	{
+		int a;
+	}
+}
+
+namespace B
+{
+	struct S
+	{
+		int b;
+	}
+}
+
+using A;
+using B;
+
+actor Root
+{
+	action main
+	{
+		S value;
+	}
+}


### PR DESCRIPTION
### Motivation
- Unqualified type names resolved through `using` namespaces previously bound to the first match encountered, which could silently select the wrong type when multiple `using` namespaces define the same name.
- The change prevents incorrect type resolution by detecting ambiguity and forcing explicit qualification or reporting an error.

### Description
- Update `LocalSemanticAnalyzer::ResolveTypeName` to collect candidate qualified names from `using` namespace paths and report a compile error when more than one candidate matches instead of picking the first one; fall back to the original name on error.
- Add `#include <vector>` and use a `std::vector<std::string_view>` helper to accumulate unique candidates and build an ambiguity message using `CompileError`.
- Add a regression test `test/test_using_ambiguous_type.mn` that declares the same type name `S` in two namespaces and uses both namespaces, and update `test/test.py` to expect an `ambiguous type reference` failure for the new test.
- Generated files encoding and line endings: Encoding: UTF-8, Line ending: CRLF.

### Testing
- No automated test suite was executed locally; the test runner was updated (`test/test.py`) to include the new regression test `test_using_ambiguous_type.mn` which should be run by CI to validate the change.
- The change is limited to type-name resolution logic in `compiler/LocalSemanticAnalyzer.cpp` and the added regression test exercises the new ambiguity path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697650f5cc988323b02201aa2d55424f)