### PR TITLE
Unify actor handle type and ban use of `Actor` as a type/keyword

### DIFF
--- a/compiler/GlobalSemanticAnalyzer.cpp
+++ b/compiler/GlobalSemanticAnalyzer.cpp
@@ -357,6 +357,21 @@ namespace mana
 			node->Set(resolvedName);
 
 		SemanticAnalyzer::ResolveTypeDescription(node);
+		RejectActorTypeName(node);
+	}
+
+	void GlobalSemanticAnalyzer::RejectActorTypeName(const std::shared_ptr<SyntaxNode>& node)
+	{
+		MANA_ASSERT(node);
+		const std::shared_ptr<TypeDescriptor>& type = node->GetTypeDescriptor();
+		if (!type || type->GetId() != TypeDescriptor::Id::Actor)
+			return;
+
+		if (type == GetTypeDescriptorFactory()->Get(TypeDescriptor::Id::Actor))
+			return;
+
+		CompileError({ "actor name '", type->GetName(), "' cannot be used as a type. Use 'actor'." });
+		node->Set(GetTypeDescriptorFactory()->Get(TypeDescriptor::Id::Actor));
 	}
 
 	void GlobalSemanticAnalyzer::ResolveVariableDescription(const std::shared_ptr<SyntaxNode>& node, const Symbol::MemoryTypeId memoryTypeId, const bool isStaticVariable)

--- a/compiler/GlobalSemanticAnalyzer.h
+++ b/compiler/GlobalSemanticAnalyzer.h
@@ -54,6 +54,7 @@ namespace mana
 		std::string_view ResolveTypeName(const std::string_view& name);
 		std::string_view ResolveExtendName(const std::string_view& name) const;
 		void ResolveTypeDescriptionScoped(const std::shared_ptr<SyntaxNode>& node);
+		void RejectActorTypeName(const std::shared_ptr<SyntaxNode>& node);
 		void ResolveVariableDescription(const std::shared_ptr<SyntaxNode>& node, const Symbol::MemoryTypeId memoryTypeId, const bool isStaticVariable);
 		void EnterNamespace(const std::string_view& name);
 		void ExitNamespace();

--- a/compiler/Lexer.l
+++ b/compiler/Lexer.l
@@ -95,7 +95,7 @@ other		.
 <INITIAL>"native"	return mana::Parser::token::tNATIVE;
 <INITIAL>"struct"	return mana::Parser::token::tSTRUCT;
 <INITIAL>"actor"	return mana::Parser::token::tACTOR;
-<INITIAL>"Actor"	return mana::Parser::token::tACTOR2;
+<INITIAL>"Actor"	{ mana::CompileError("reserved keyword 'Actor' is not allowed"); return mana::Parser::token::tIDENTIFIER; }
 <INITIAL>"phantom"	return mana::Parser::token::tPHANTOM;
 <INITIAL>"action"	return mana::Parser::token::tACTION;
 <INITIAL>"module"	return mana::Parser::token::tMODULE;

--- a/compiler/LocalSemanticAnalyzer.cpp
+++ b/compiler/LocalSemanticAnalyzer.cpp
@@ -161,6 +161,21 @@ namespace mana
 			node->Set(resolvedName);
 
 		SemanticAnalyzer::ResolveTypeDescription(node);
+		RejectActorTypeName(node);
+	}
+
+	void LocalSemanticAnalyzer::RejectActorTypeName(const std::shared_ptr<SyntaxNode>& node)
+	{
+		MANA_ASSERT(node);
+		const std::shared_ptr<TypeDescriptor>& type = node->GetTypeDescriptor();
+		if (!type || type->GetId() != TypeDescriptor::Id::Actor)
+			return;
+
+		if (type == GetTypeDescriptorFactory()->Get(TypeDescriptor::Id::Actor))
+			return;
+
+		CompileError({ "actor name '", type->GetName(), "' cannot be used as a type. Use 'actor'." });
+		node->Set(GetTypeDescriptorFactory()->Get(TypeDescriptor::Id::Actor));
 	}
 
 	void LocalSemanticAnalyzer::ResolveVariableDescription(const std::shared_ptr<SyntaxNode>& node, const Symbol::MemoryTypeId memoryTypeId, const bool isStaticVariable)
@@ -857,6 +872,11 @@ DO_RECURSIVE:
 				TypeDescriptor::Id t1, t2;
 				if (GetNodeType(&t1, &t2, node))
 				{
+					if (t1 == TypeDescriptor::Id::Actor || t2 == TypeDescriptor::Id::Actor)
+					{
+						CompileError("actor comparisons are limited to == and !=");
+						break;
+					}
 					AutoCast(node);
 					TypeDescriptor::Compatible(node->GetLeftNode()->GetTypeDescriptor(), node->GetRightNode()->GetTypeDescriptor());
 					switch (t1)
@@ -890,6 +910,11 @@ DO_RECURSIVE:
 				TypeDescriptor::Id t1, t2;
 				if (GetNodeType(&t1, &t2, node))
 				{
+					if (t1 == TypeDescriptor::Id::Actor || t2 == TypeDescriptor::Id::Actor)
+					{
+						CompileError("actor comparisons are limited to == and !=");
+						break;
+					}
 					AutoCast(node);
 					TypeDescriptor::Compatible(node->GetLeftNode()->GetTypeDescriptor(), node->GetRightNode()->GetTypeDescriptor());
 					switch (t1)
@@ -923,6 +948,11 @@ DO_RECURSIVE:
 				TypeDescriptor::Id t1, t2;
 				if (GetNodeType(&t1, &t2, node))
 				{
+					if (t1 == TypeDescriptor::Id::Actor || t2 == TypeDescriptor::Id::Actor)
+					{
+						CompileError("actor comparisons are limited to == and !=");
+						break;
+					}
 					AutoCast(node);
 					TypeDescriptor::Compatible(node->GetLeftNode()->GetTypeDescriptor(), node->GetRightNode()->GetTypeDescriptor());
 					switch (t1)
@@ -956,6 +986,11 @@ DO_RECURSIVE:
 				TypeDescriptor::Id t1, t2;
 				if (GetNodeType(&t1, &t2, node))
 				{
+					if (t1 == TypeDescriptor::Id::Actor || t2 == TypeDescriptor::Id::Actor)
+					{
+						CompileError("actor comparisons are limited to == and !=");
+						break;
+					}
 					AutoCast(node);
 					TypeDescriptor::Compatible(node->GetLeftNode()->GetTypeDescriptor(), node->GetRightNode()->GetTypeDescriptor());
 					switch (t1)

--- a/compiler/LocalSemanticAnalyzer.h
+++ b/compiler/LocalSemanticAnalyzer.h
@@ -52,6 +52,7 @@ namespace mana
 		[[nodiscard]] std::string_view ResolveAlias(const std::string_view& name) const;
 		[[nodiscard]] std::string_view ResolveTypeName(const std::string_view& name) const;
 		void ResolveTypeDescriptionScoped(const std::shared_ptr<SyntaxNode>& node);
+		void RejectActorTypeName(const std::shared_ptr<SyntaxNode>& node);
 		void ResolveVariableDescription(const std::shared_ptr<SyntaxNode>& node, const Symbol::MemoryTypeId memoryTypeId, const bool isStaticVariable);
 
 		void EnterNamespace(const std::string_view& name);

--- a/compiler/Parser.yy
+++ b/compiler/Parser.yy
@@ -72,7 +72,7 @@ mana (compiler)
 %token	<std::shared_ptr<mana::TypeDescriptor>> tTYPE
 
 %token	tDEFINE tUNDEF tINCLUDE tIMPORT
-%token	tNATIVE tSTRUCT tACTOR tACTOR2 tPHANTOM tACTION tMODULE tEXTEND
+%token	tNATIVE tSTRUCT tACTOR tPHANTOM tACTION tMODULE tEXTEND
 %token	tNAMESPACE tUSING
 %token	tFALSE tTRUE tPRIORITY tSELF tSENDER tNIL
 %token	tREQUEST tAwaitStart tAwaitCompletion tJOIN
@@ -232,7 +232,7 @@ function		: variable_type tIDENTIFIER '(' arg_decls ')' block
 					{ $$ = mParsingDriver->CreateInternalFunction($1, $2, $4, $6); }
 				;
 
-variable_type	: tACTOR2
+variable_type	: tACTOR
 					{ $$ = mParsingDriver->CreateActorTypeDescription(); }
 				| qualified_name
 					{ $$ = mParsingDriver->CreateTypeDescription($1); }

--- a/document/primer_chapter_2-en.md
+++ b/document/primer_chapter_2-en.md
@@ -1,9 +1,9 @@
 ## Chapter 2 Program Structure
 ## actor and action
-In Mana, one Actor block corresponds one-to-one to one character in the game.
-In other words, if there is no single Actor block in the source, there is no character in the game.
-Within the Actor block, an Action block is placed to define the character's behavior by describing the character's actions.
-Statements within an Action must always end with a ; or be enclosed in {}.
+In Mana, one actor block corresponds one-to-one to one character in the game.
+In other words, if there is no single actor block in the source, there is no character in the game.
+Within the actor block, an action block is placed to define the character's behavior by describing the character's actions.
+Statements within an action must always end with a ; or be enclosed in {}.
 The part enclosed in {} is called a block and can be treated as a whole process.
 
 ## Who called me?
@@ -58,7 +58,7 @@ actor Wife
 }
 ```
 
-## Actor Actions
+## actor actions
 Mana not only allows you to associate actors with characters, but also to associate them with space-defining objects to define actions that cannot be realized by characters.
 For example, a box can be placed in a space, and various conditions, such as "the character passes through the box," can trigger an interrupt. Using this function, it is easy to create a situation where "a box is placed on the road, and when an actor enters the box, the actor-guard will be alerted.
 

--- a/document/primer_chapter_3-en.md
+++ b/document/primer_chapter_3-en.md
@@ -323,9 +323,9 @@ ABORT:
 ### request
 Requests an actor, including yourself. If the requestor has already executed or reserved a request of the same level, the request will be invalid.
 
-request(Priority, ActorRef->ActionName);
+request(Priority, actor->ActionName);
 Priority ... Priority
-ActorRef ... Actor name
+actor ... actor name
 ActionName ... Action name
 
 ```

--- a/document/primer_chapter_3-ja.md
+++ b/document/primer_chapter_3-ja.md
@@ -323,9 +323,9 @@ ABORT:
 ### request
 自分を含めたアクターにリクエストします。リクエスト先が同レベルのリクエストを実行または予約されていた場合はそのリクエストは無効になります。
 
-request(Priority, ActorRef->ActionName);
+request(Priority, actor->ActionName);
 Priority …　プライオリティ
-ActorRef　…　アクター名
+actor　…　アクター名
 ActionName … アクション名
 
 ```

--- a/document/primer_chapter_5-en.md
+++ b/document/primer_chapter_5-en.md
@@ -17,7 +17,7 @@ actor NiceGuy
     extend TestModule;
 }
 ```
-## Actor and Phantom
+## actor and phantom
 When an actor is defined, the actor exists. However, when Mana is used for unspecified AI such as enemy thoughts in battle, it is not realistic to define an actor for each number of enemies. Therefore, it is necessary to have a concept that defines actions but duplicates the entities at runtime. In Mana, this is called a phantom. The request for the replicated phantom has not been resolved.
 
 ```
@@ -26,7 +26,7 @@ phantom TestPhantom.
     action dead;
 }
 ```
-## Actor inheritance
+## actor inheritance
 ''Specification under consideration''
 
 ```

--- a/document/primer_chapter_5-ja.md
+++ b/document/primer_chapter_5-ja.md
@@ -17,7 +17,7 @@ actor NiceGuy
     extend TestModule;
 }
 ```
-## ActorとPhantom
+## actorとphantom
 actorを定義するとそのactorは存在する事になりますが、戦闘における敵の思考など不特定多数のAIにManaを利用する時、敵の人数分actorを定義する事は現実的ではありません。 そこでactionは定義するが実体は実行時に複製される概念が必要です。それをManaではPhantomと呼びます。 複製されたPhantomに対してのrequestが解決されていない。
 
 ```
@@ -26,7 +26,7 @@ phantom TestPhantom
     action dead;
 }
 ```
-## Actorの継承
+## actorの継承
 ''仕様検討中''
 
 ```

--- a/sample/sample_struct.mn
+++ b/sample/sample_struct.mn
@@ -10,7 +10,7 @@ struct TestStruct1
 	int digitValue;
 	string stringValue;
 	float realValue;
-	Actor actorValue;
+	actor actorValue;
 }
 
 struct TestStruct2

--- a/test/test_action_ref_expression.mn
+++ b/test/test_action_ref_expression.mn
@@ -18,7 +18,7 @@ actor Root
 
 	action main
 	{
-		Actor target;
+		actor target;
 		request(1, target->ping);
 		request(1, self->ping);
 		request(1, sender->ping);

--- a/test/test_struct_01.mn
+++ b/test/test_struct_01.mn
@@ -10,7 +10,7 @@ struct TestStruct1
 	int digitValue;
 	string stringValue;
 	float realValue;
-	Actor actorValue;
+	actor actorValue;
 }
 
 struct TestStruct2


### PR DESCRIPTION
### Motivation
- Eliminate confusion between the `actor` declaration and the old `Actor` type by making `actor` the single handle/type token and forbidding `Actor` as a type/identifier. 
- Prevent using actor declaration names as types (e.g. `Enemy e;`) and restrict invalid actor operations to simplify the type system.

### Description
- Lexer: `Actor` is now rejected with a compile-time message while `actor` remains the reserved keyword (`compiler/Lexer.l`).
- Parser: variable-type parsing now uses the `tACTOR` token for the actor handle type instead of a separate `tACTOR2` (`compiler/Parser.yy`).
- Semantic analysis: introduced `RejectActorTypeName` in `GlobalSemanticAnalyzer` and `LocalSemanticAnalyzer` to forbid using actor definition names as types and coerce such usages to the builtin `actor` type, and added checks to disallow ordering comparisons (`<`, `>`, `<=`, `>=`) on actor values, allowing only `==`/`!=` (`compiler/GlobalSemanticAnalyzer.{h,cpp}`, `compiler/LocalSemanticAnalyzer.{h,cpp}`).
- Samples/tests/docs: updated source/examples and docs to use `actor` in type positions and examples (e.g. `sample/sample_struct.mn`, `test/test_struct_01.mn`, `test/test_action_ref_expression.mn`, and various `document/primer_*` files).

### Testing
- No automated test suite or build was executed for this change. 
- Performed repository-wide textual updates and searches to locate and replace `tACTOR2`/`Actor` usages in source, samples and docs and verified the edits were committed; no compile or unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978be5cc2dc8323a43254d1dc2ec3bb)