### PR TITLE
Add Mana scripting coding convention document

### DIFF
--- a/CodingConvention-ja.md
+++ b/CodingConvention-ja.md
@@ -1,0 +1,182 @@
+# Mana スクリプト コーディング規約 v0.1
+
+## 0. 目的
+
+* **actor 境界**（状態と責務）を明確にする
+* **request の流れ**（誰が誰に何を依頼したか）を追いやすくする
+* レビュー時に **意図の誤読**を減らす
+
+これは**プロジェクトレベルの規約**であり、言語の制約ではありません。
+
+---
+
+## 1. フォーマット
+
+### 1.1 インデント・改行
+
+* インデント：4スペースまたはタブ
+* タブ禁止
+* 1行の目安：120文字（超える場合は適切に改行）
+
+### 1.2 ブレース
+
+* **Allman スタイル**
+
+```mn
+actor Foo
+{
+    action bar
+    {
+    }
+}
+```
+
+---
+
+## 2. ファイルと構造
+
+### 2.1 ファイル命名
+
+* 拡張子：`.mn`
+* ファイル名：`PascalCase`（例：`EnemyAI.mn`）
+
+### 2.2 namespace
+
+* **必須ではない（推奨）**
+* 大規模化・ライブラリ化・プラグイン化を見据える場合は特に推奨
+
+```mn
+namespace Game::AI;
+```
+
+### 2.3 using
+
+* 使用する場合は、**ファイル先頭（namespace の直後）に集約**
+* 乱用しない（参照関係が読めなくなる）
+
+---
+
+## 3. 命名規則（最重要）
+
+## 3.1 actor / action / 変数
+
+### actor 名
+
+* `PascalCase`
+* 役割が分かる名詞（例：`EnemyController`, `BattleService`）
+
+### action 名
+
+* `lowerCamelCase`
+* **動詞から始める名前を推奨**
+* **`onXxx` という命名には触れない**（規約として言及しない）
+
+推奨例：
+
+* `initialize`, `main`, `think`, `update`, `attack`, `acquireTarget`
+
+### ローカル変数
+
+* `lowerCamelCase`（例：`targetId`, `retryCount`）
+
+### actor 状態（フィールド）
+
+* `mLowerCamelCase`（例：`mState`, `mTargetId`）
+
+---
+
+## 3.2 定数（Constant）
+
+### 命名
+
+* **定数は必ず `k` 接頭辞**
+* 形式：`kPascalCase`
+* `const` 宣言を必須
+
+```mn
+const int kMaxRetry = 3;
+const int kThinkPriority = 50;
+```
+
+### 意味定義
+
+> `kXxx` は **不変のルール・制約・閾値・デフォルト値**を表す
+> （actor の状態ではない・書き換えない）
+
+---
+
+## 3.3 グローバル変数（可変）
+
+### 方針
+
+* **原則禁止**
+* どうしても必要な場合のみ例外として許可し、命名で明示する
+
+### 命名
+
+* **`g` 接頭辞**
+* 形式：`gLowerCamelCase`
+
+```mn
+int  gFrameCounter;
+bool gIsDebugMode;
+```
+
+### 制約（セット運用）
+
+* `gXxx` には **所有者（書き込み責務を持つ actor/action）をコメントで明記**
+* 書き込み箇所を極力 1 箇所に限定（分散させない）
+* gameplay の中核ロジックでは使用しない（デバッグ・統計・一時的制御用途に限定）
+
+```mn
+// Owned by DebugController::update
+bool gIsDebugDrawEnabled;
+```
+
+---
+
+## 4. request（メッセージ送信）
+
+## 4.1 第1引数の意味（確定）
+
+> `request(priority, Target->action)` の第1引数は **常に優先度（priority）**
+
+* 遅延時間・フレーム数・秒数ではない
+
+```mn
+request(100, Enemy->think);
+request(10,  Enemy->idle);
+```
+
+## 4.2 優先度の表現
+
+* マジックナンバーを避け、**`kXxx` 定数化を推奨**
+
+```mn
+const int kThinkPriority = 50;
+request(kThinkPriority, Enemy->think);
+```
+
+## 4.3 整形（長い場合）
+
+```mn
+request(
+    kThinkPriority,
+    Enemy->think
+);
+```
+
+---
+
+## 5. action の粒度（設計ルール）
+
+* **1 action = 1 intent**（目的が1つになるよう分割）
+* `main` はオーケストレーション寄りにして、内部ロジックを詰め込みすぎない
+* request 連鎖が長くなる場合は action を分割してフェーズ化する
+
+---
+
+## 6. コメント
+
+* コメントは主に **「なぜ」**を書く（何をしているかはコードで読む）
+* actor には役割・保持状態の意味・主要な request 先を短く書くとレビューが速い

--- a/CodingConvention.md
+++ b/CodingConvention.md
@@ -1,0 +1,216 @@
+# Mana Script Coding Convention v0.1
+
+## 0. Purpose
+
+This convention aims to:
+
+* Clearly define **actor boundaries** (state vs responsibility)
+* Make **message flow via `request`** easy to follow
+* Reduce **misinterpretation during reviews and maintenance**
+
+This is a **project-level convention**, not a language restriction.
+
+---
+
+## 1. Formatting
+
+### 1.1 Indentation & Line Length
+
+* Indentation: 4 spaces or tabs
+* Tabs are forbidden
+* Line length guideline: **120 characters**
+  * Break lines when exceeded
+
+### 1.2 Braces
+
+* **Allman style**
+
+```mn
+actor Foo
+{
+    action bar
+    {
+    }
+}
+```
+
+---
+
+## 2. Files & Structure
+
+### 2.1 File Naming
+
+* Extension: `.mn`
+* File name: `PascalCase`
+  Example: `EnemyAI.mn`
+
+### 2.2 namespace
+
+* **Not mandatory, but recommended**
+* Strongly recommended for:
+
+  * Large projects
+  * Libraries / plugins
+  * Long-term maintenance
+
+```mn
+namespace Game::AI;
+```
+
+### 2.3 using
+
+* If used, place all `using` declarations:
+
+  * At the top of the file
+  * Immediately after `namespace`
+* Avoid overuse to keep dependencies explicit
+
+---
+
+## 3. Naming Rules (Critical)
+
+## 3.1 actor / action / variables
+
+### actor Names
+
+* `PascalCase`
+* Use nouns that clearly describe responsibility
+  Examples: `EnemyController`, `BattleService`
+
+### action Names
+
+* `lowerCamelCase`
+* **Verb-first naming is recommended**
+* **The convention does not define or restrict `onXxx` naming**
+
+Recommended examples:
+
+* `initialize`, `main`, `think`, `update`
+* `attack`, `acquireTarget`
+
+### Local Variables
+
+* `lowerCamelCase`
+  Example: `targetId`, `retryCount`
+
+### actor State (Fields)
+
+* `mLowerCamelCase`
+  Example: `mState`, `mTargetId`
+
+---
+
+## 3.2 Constants
+
+### Naming
+
+* **All constants must use the `k` prefix**
+* Format: `kPascalCase`
+* `const` declaration is mandatory
+
+```mn
+const int kMaxRetry = 3;
+const int kThinkPriority = 50;
+```
+
+### Semantic Definition
+
+> `kXxx` represents **immutable rules, constraints, thresholds, or default values**
+> They are **not actor state** and must never be modified.
+
+---
+
+## 3.3 Global Variables (Mutable)
+
+### Policy
+
+* **Prohibited by default**
+* Allowed only as explicit exceptions
+
+### Naming
+
+* **`g` prefix is mandatory**
+* Format: `gLowerCamelCase`
+
+```mn
+int  gFrameCounter;
+bool gIsDebugMode;
+```
+
+### Required Constraints
+
+When a `gXxx` variable is used:
+
+* The **owner** (actor / action responsible for writing) must be documented
+* Writes should be limited to as few locations as possible (ideally one)
+* Must not be used for core gameplay logic
+  (debugging, diagnostics, statistics only)
+
+```mn
+// Owned by DebugController::update
+bool gIsDebugDrawEnabled;
+```
+
+---
+
+## 4. request (Message Sending)
+
+## 4.1 First Argument (Fixed Meaning)
+
+> In `request(priority, Target->action)`,
+> **the first argument always represents priority**
+
+* It does **not** represent delay, frame count, or time
+
+```mn
+request(100, Enemy->think);
+request(10,  Enemy->idle);
+```
+
+---
+
+## 4.2 Priority Values
+
+* Avoid magic numbers
+* **Prefer constants (`kXxx`)**
+
+```mn
+const int kThinkPriority = 50;
+request(kThinkPriority, Enemy->think);
+```
+
+---
+
+## 4.3 Formatting (Long Calls)
+
+```mn
+request(
+    kThinkPriority,
+    Enemy->think
+);
+```
+
+---
+
+## 5. action Granularity (Design Rule)
+
+* **One action = one intent**
+* `main` should act as an orchestrator
+
+  * Avoid embedding complex logic directly
+* If request chains grow long:
+
+  * Split into multiple actions
+  * Use phased execution
+
+---
+
+## 6. Comments
+
+* Comments should primarily explain **“why”**, not “what”
+* For actors, short comments describing:
+
+  * Responsibility
+  * Meaning of held state
+  * Key outgoing requests
+    are strongly recommended


### PR DESCRIPTION
# Overview
This PR introduces a **formal coding convention** for Mana scripts.

The goal is to standardize naming, request semantics, and global state handling
while staying aligned with Mana’s actor-model design.

---

# What’s Included
- New document: `CodingConvention.md`
- Clearly defined rules for:
  - Constants (`kXxx`)
  - Actor state (`mXxx`)
  - Global mutable variables (`gXxx`, exceptional use)
  - Action naming (verb-first)
  - `request(priority, Target->action)` semantics
- Formatting and structural guidelines
- Recommended (non-mandatory) use of `namespace`

---

# Key Rules (Summary)
- `kXxx`
  Immutable constants (rules / constraints)

- `mXxx`
  Actor-owned state

- `gXxx`
  Exceptional global mutable state (discouraged, documented ownership required)

- `request(priority, ...)`
  First argument is **always priority**, never delay or time

---

# Rationale
Mana scripts rely heavily on:
- Human readability
- Message-passing clarity
- Explicit state ownership

This convention minimizes ambiguity and prevents patterns that silently break
the actor model (e.g. shared mutable state).

---

# Compatibility
- No runtime or language changes
- No backward compatibility guarantees required
- Documentation-only change

---

# Review Notes
- Please focus review on:
  - Naming clarity
  - Semantic consistency
  - Alignment with current Mana design philosophy
