### PR TITLE
Select scalar types by pointer width (64-bit doubles/ints on 64-bit hosts)

### DIFF
--- a/runner/common/Type.h
+++ b/runner/common/Type.h
@@ -17,32 +17,35 @@ namespace mana
 	//! Signed size integer type.
 	using ssize_t = intptr_t;
 #endif
-/*
+
 #if UINTPTR_MAX == UINT64_MAX
+	using float_t = double;
+	using int_t = std::int64_t;
 #elif UINTPTR_MAX == UINT32_MAX
-#else
-#error "unsupport pointer size"
-#endif
-*/
 	using float_t = float;
 	using int_t = std::int32_t;
+#else
+	#error "unsupported pointer size"
+#endif
 
 	using address_t = std::uint32_t;
 	static constexpr address_t InvalidAddress = static_cast<address_t>(~0);
 
 	using offset_t = std::int32_t;
 
+	static_assert(sizeof(address_t) == 4, "address_t must remain 32-bit");
+
 	/*!
-	Determine if the address is invalid.
-	*/
+	 * Determine if the address is invalid.
+	 */
 	[[nodiscard]] inline bool IsValid(const address_t address)
 	{
 		return address != InvalidAddress;
 	}
 
 	/*!
-	Check the value range and cast to address_t
-	*/
+	 * Check the value range and cast to address_t
+	 */
 	template<typename T>
 	[[nodiscard]] inline address_t ToAddress(const T size)
 	{
@@ -68,8 +71,8 @@ namespace mana
 	}
 
 	/*!
-	Check the value range and cast to offset_t
-	*/
+	 * Check the value range and cast to offset_t
+	 */
 	template<typename T>
 	[[nodiscard]] inline offset_t ToOffset(const T size)
 	{


### PR DESCRIPTION
### Motivation
- Ensure numeric precision and integer range use native widths on 64-bit hosts while preserving the VM's 32-bit address model so address space semantics remain unchanged.

### Description
- Updated `runner/common/Type.h` to choose `float_t`/`int_t` based on `UINTPTR_MAX`, using `double`/`std::int64_t` when running on a 64-bit pointer-width host and `float`/`std::int32_t` on 32-bit hosts.
- Kept `address_t = std::uint32_t` and added `static_assert(sizeof(address_t) == 4, "address_t must remain 32-bit");` to enforce the address-width invariant at compile time.
- Added an explicit `#error` branch for unsupported pointer sizes to provide a clear compile-time failure on exotic platforms.

### Testing
- Performed automated source inspections and validations including `rg` searches to find type usages, file inspections with `sed`/`nl`, and checks of the change with `git diff`/`git show --stat`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984bf19660483238422272b3071aae0)